### PR TITLE
Eliminar service de Gmail helpers y soportar alias de fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,14 @@ Para trabajar sin acceso a Gmail real, define:
 ```bash
 export USE_FAKE_GMAIL=1
 export FAKE_EMAILS_PATH=tests/fixtures/emails_home.json  # opcional
+# Alias aceptado: FAKE_EMAILS_FILE
 ```
 
 Los tests usan este modo y funcionan sin instalar los extras de LLM o audio.
+
+Los helpers de Gmail (`listar`, `leer_ultimo`, `remitentes_hoy`, `contar_no_leidos`,
+`buscar` y `resumen_correos_hoy`) ya no aceptan el objeto `service`; lo obtienen
+internamente. Cualquier argumento inesperado se ignora y se registra un *warning*.
 
 ### Nota sobre proxies
 

--- a/core/action_router.py
+++ b/core/action_router.py
@@ -17,7 +17,7 @@ def ejecutar_accion(intencion, comando=None, contexto=None, filtros=None):
 
     # Acción: leer último correo (Primary)
     if accion == "leer_ultimo":
-        meta = leer_ultimo(contexto["service"])
+        meta = leer_ultimo()
         if not meta:
             return "No encontré correos recientes."
         headers = {h["name"].lower(): h["value"] for h in meta.get("payload", {}).get("headers", [])}
@@ -28,20 +28,20 @@ def ejecutar_accion(intencion, comando=None, contexto=None, filtros=None):
 
     # Acción: contar no leídos (Primary)
     if accion == "contar_no_leidos":
-        cantidad = contar_no_leidos(contexto["service"])
+        cantidad = contar_no_leidos()
         return f"Tienes {cantidad} correos sin leer."
 
     # Acción: remitentes de hoy (Primary)
     if accion == "remitentes_hoy":
-        return remitentes_hoy(contexto["service"])
+        return remitentes_hoy()
 
     # Acción: resumen de correos de hoy (mantiene tu impl. actual)
     if accion == "resumen_hoy":
-        return resumen_correos_hoy(contexto["service"])
+        return resumen_correos_hoy()
 
     # Acción: detectar correos importantes (heurística simple sobre el resumen)
     if accion == "correos_importantes":
-        raw = resumen_correos_hoy(contexto["service"], cantidad=50)
+        raw = resumen_correos_hoy(cantidad=50)
         urgentes = [
             m for m in raw.split("-----")
             if any(x in m.lower() for x in ["urgente", "importante", "reunión", "responder", "hoy"])
@@ -53,7 +53,7 @@ def ejecutar_accion(intencion, comando=None, contexto=None, filtros=None):
     # Acción: listar correos recientes (resumidos)
     if accion == "listar_correos":
         print("✔️ Ejecutando listar_correos con filtros:", filtros)
-        raw = resumen_correos_hoy(contexto["service"], cantidad=50)
+        raw = resumen_correos_hoy(cantidad=50)
         lista = [m.strip() for m in raw.split("-----") if m.strip()]
 
         remitente_filtro = filtros.get("remite", "").lower().strip()
@@ -77,7 +77,7 @@ def ejecutar_accion(intencion, comando=None, contexto=None, filtros=None):
     # Acción: buscar correo por remitente
     if accion in ["buscar_correo", "buscar_correos"]:
         remitente_filtro = filtros.get("remite", "").lower().strip()
-        raw = resumen_correos_hoy(contexto["service"], cantidad=10)
+        raw = resumen_correos_hoy(cantidad=10)
         lista = [m.strip() for m in raw.split("-----") if m.strip()]
         encontrados = [m for m in lista if remitente_filtro in m.lower()]
 

--- a/core/gmail/__init__.py
+++ b/core/gmail/__init__.py
@@ -2,23 +2,18 @@
 from __future__ import annotations
 import os
 import time
-import functools
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 USE_FAKE = os.getenv("USE_FAKE_GMAIL", "false").lower() in ("1", "true", "yes")
 BACKEND = "fake" if USE_FAKE else "real"
 
 
-def _wrap(name, fn):
-    @functools.wraps(fn)
-    def wrapped(*args, **kwargs):
-        start = time.perf_counter()
-        result = fn(*args, **kwargs)
-        duration_ms = (time.perf_counter() - start) * 1000
-        print(f"{name} backend={BACKEND} duration_ms={duration_ms:.2f}")
-        return result
-
-    return wrapped
+def _timed(name: str, fn):
+    start = time.perf_counter()
+    result = fn()
+    duration_ms = (time.perf_counter() - start) * 1000
+    print(f"{name} backend={BACKEND} duration_ms={duration_ms:.2f}")
+    return result
 
 
 if USE_FAKE:
@@ -29,12 +24,6 @@ if USE_FAKE:
         contar_no_leidos as _contar_no_leidos,
         buscar as _buscar,
     )
-
-    listar = _wrap("listar", _listar)
-    remitentes_hoy = _wrap("remitentes_hoy", _remitentes_hoy)
-    leer_ultimo = _wrap("leer_ultimo", _leer_ultimo)
-    contar_no_leidos = _wrap("contar_no_leidos", _contar_no_leidos)
-    buscar = _wrap("buscar", _buscar)
 else:
     from .leer import (
         listar as _listar,
@@ -44,11 +33,43 @@ else:
     )
     from .buscar import buscar as _buscar
 
-    listar = _wrap("listar", _listar)
-    remitentes_hoy = _wrap("remitentes_hoy", _remitentes_hoy)
-    leer_ultimo = _wrap("leer_ultimo", _leer_ultimo)
-    contar_no_leidos = _wrap("contar_no_leidos", _contar_no_leidos)
-    buscar = _wrap("buscar", _buscar)
+
+def listar(max_results: int | None = None, base_query: str | None = None, *args, **kwargs) -> List[Dict[str, Any]]:
+    if args or kwargs:
+        print(f"⚠️ listar ignoró args extra: args={args} kwargs={kwargs}")
+
+    call_kwargs: Dict[str, Any] = {}
+    if max_results is not None:
+        call_kwargs["max_results"] = max_results
+    if base_query is not None:
+        call_kwargs["base_query"] = base_query
+
+    return _timed("listar", lambda: _listar(**call_kwargs))
+
+
+def remitentes_hoy(*args, **kwargs) -> List[str]:
+    if args or kwargs:
+        print(f"⚠️ remitentes_hoy ignoró args extra: args={args} kwargs={kwargs}")
+    return _timed("remitentes_hoy", _remitentes_hoy)
+
+
+def leer_ultimo(*args, **kwargs) -> Dict[str, Any]:
+    if args or kwargs:
+        print(f"⚠️ leer_ultimo ignoró args extra: args={args} kwargs={kwargs}")
+    return _timed("leer_ultimo", _leer_ultimo)
+
+
+def contar_no_leidos(*args, **kwargs) -> int:
+    if args or kwargs:
+        print(f"⚠️ contar_no_leidos ignoró args extra: args={args} kwargs={kwargs}")
+    return _timed("contar_no_leidos", _contar_no_leidos)
+
+
+def buscar(query: str, max_results: int = 20, *args, **kwargs) -> List[Dict[str, Any]]:
+    if args or kwargs:
+        print(f"⚠️ buscar ignoró args extra: args={args} kwargs={kwargs}")
+    return _timed("buscar", lambda: _buscar(query=query, max_results=max_results))
+
 
 __all__ = [
     "listar",

--- a/core/gmail/buscar.py
+++ b/core/gmail/buscar.py
@@ -9,9 +9,9 @@ from .leer import (
 from .auth import get_authenticated_service
 
 
-def buscar(query: str, max_results: int = 20, service=None) -> List[Dict[str, Any]]:
+def buscar(query: str, max_results: int = 20) -> List[Dict[str, Any]]:
     """Busqueda simple en Gmail API manteniendo orden y forma."""
-    service = service or get_authenticated_service()
+    service = get_authenticated_service()
     q = (query or "").strip()
     if not q:
         return []

--- a/core/gmail/leer.py
+++ b/core/gmail/leer.py
@@ -95,9 +95,9 @@ def _get_message_metadata(service, msg_id: str) -> Dict[str, Any]:
 
     return msg
 
-def listar(service=None, max_results: int = GMAIL_MAX_RESULTS, base_query: str | None = None) -> List[Dict[str, Any]]:
+def listar(max_results: int = GMAIL_MAX_RESULTS, base_query: str | None = None) -> List[Dict[str, Any]]:
     """Lista correos de la bandeja principal."""
-    service = service or get_authenticated_service()
+    service = get_authenticated_service()
     ids = _list_primary_message_ids(service, max_results, base_query=base_query)
     out: List[Dict[str, Any]] = []
     for mid in ids:
@@ -107,11 +107,11 @@ def listar(service=None, max_results: int = GMAIL_MAX_RESULTS, base_query: str |
     return out
 
 
-def remitentes_hoy(service=None) -> List[str]:
+def remitentes_hoy() -> List[str]:
     """
     Retorna remitentes de últimos N correos en Primary estrictamente de hoy (≈ últimas 24h).
     """
-    service = service or get_authenticated_service()
+    service = get_authenticated_service()
     after = get_rfc3339_today()
     ids = _list_primary_message_ids(
         service, GMAIL_MAX_RESULTS, base_query=f"after:{after}"
@@ -128,11 +128,11 @@ def remitentes_hoy(service=None) -> List[str]:
     return remitentes
 
 
-def leer_ultimo(service=None) -> Dict[str, Any]:
+def leer_ultimo() -> Dict[str, Any]:
     """
     Retorna metadata del último correo 'bueno' (Primary).
     """
-    service = service or get_authenticated_service()
+    service = get_authenticated_service()
     ids = _list_primary_message_ids(service, max_results=1)
     if not ids:
         return {}
@@ -140,11 +140,11 @@ def leer_ultimo(service=None) -> Dict[str, Any]:
     return meta or {}
 
 
-def contar_no_leidos(service=None) -> int:
+def contar_no_leidos() -> int:
     """
     Cuenta no leídos SOLO en Primary (excluyendo Social/Promos/etc.).
     """
-    service = service or get_authenticated_service()
+    service = get_authenticated_service()
     resp = (
         service.users()
         .messages()

--- a/core/gmail_client.py
+++ b/core/gmail_client.py
@@ -13,11 +13,11 @@ from utils.summarizer import resumen_correos_hoy as _resumen_correos_hoy
 GMAIL_MAX_RESULTS = int(os.getenv("GMAIL_MAX_RESULTS", "10"))
 
 
-def contar_correos_no_leidos(service):
-    """
-    Compat: reporta string con conteo de no leídos en Primary.
-    """
-    cantidad = _contar_no_leidos(service)
+def contar_correos_no_leidos(*args, **kwargs):
+    """Compat: reporta string con conteo de no leídos en Primary."""
+    if args or kwargs:
+        print(f"⚠️ contar_correos_no_leidos ignoró args extra: args={args} kwargs={kwargs}")
+    cantidad = _contar_no_leidos()
     if cantidad == 0:
         return "No tienes correos sin leer."
     if cantidad == 1:
@@ -25,11 +25,11 @@ def contar_correos_no_leidos(service):
     return f"Tienes {cantidad} correos sin leer."
 
 
-def remitentes_hoy(service):
-    """
-    Compat: devuelve string con remitentes únicos de las últimas 24h (Primary).
-    """
-    remitentes: List[str] = _remitentes_hoy(service)
+def remitentes_hoy(*args, **kwargs):
+    """Compat: devuelve string con remitentes únicos de las últimas 24h (Primary)."""
+    if args or kwargs:
+        print(f"⚠️ remitentes_hoy ignoró args extra: args={args} kwargs={kwargs}")
+    remitentes: List[str] = _remitentes_hoy()
     if not remitentes:
         return "Hoy no has recibido correos nuevos."
 
@@ -40,15 +40,15 @@ def remitentes_hoy(service):
     return f"Hoy te escribieron {nombres}."
 
 
-def leer_ultimo_correo(service):
-    """
-    Compat: retorna dict con metadata del último correo (Primary).
-    """
-    return _leer_ultimo(service)
+def leer_ultimo_correo(*args, **kwargs):
+    """Compat: retorna dict con metadata del último correo (Primary)."""
+    if args or kwargs:
+        print(f"⚠️ leer_ultimo_correo ignoró args extra: args={args} kwargs={kwargs}")
+    return _leer_ultimo()
 
 
-def resumen_correos_hoy(service, cantidad: int = 10):
-    """
-    Delegado al summarizer actual. Mantiene la firma para código legado.
-    """
-    return _resumen_correos_hoy(service, cantidad=cantidad)
+def resumen_correos_hoy(cantidad: int = 10, *args, **kwargs):
+    """Delegado al summarizer actual. Mantiene compatibilidad."""
+    if args or kwargs:
+        print(f"⚠️ resumen_correos_hoy ignoró args extra: args={args} kwargs={kwargs}")
+    return _resumen_correos_hoy(cantidad=cantidad)

--- a/tests/test_comandos.py
+++ b/tests/test_comandos.py
@@ -1,0 +1,49 @@
+import os
+
+os.environ["USE_FAKE_GMAIL"] = "1"
+os.environ["FAKE_EMAILS_PATH"] = "tests/fixtures/emails_home.json"
+
+import importlib.util
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+import core.action_router as router
+
+spec = importlib.util.spec_from_file_location(
+    "api_app", ROOT / "api_gmail_backend" / "app.py"
+)
+api_app = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(api_app)
+app = api_app.app
+
+
+def test_comandos():
+    app.testing = True
+    client = app.test_client()
+
+    original_contar = router.contar_no_leidos
+    original_remitentes = router.remitentes_hoy
+    original_resumen = router.resumen_correos_hoy
+
+    router.contar_no_leidos = lambda: 3
+    router.remitentes_hoy = lambda: ["alice@example.com"]
+    router.resumen_correos_hoy = lambda cantidad=10: "uno\n-----\ndos"
+
+    try:
+        resp = client.post("/api/gmail/comando", json={"comando": "¿Tengo correos sin leer?"})
+        assert resp.status_code == 200
+        assert any(ch.isdigit() for ch in resp.get_json()["respuesta"])
+
+        resp = client.post("/api/gmail/comando", json={"comando": "¿Quién me escribió hoy?"})
+        assert resp.status_code == 200
+        assert isinstance(resp.get_json()["respuesta"], list)
+
+        resp = client.post("/api/gmail/comando", json={"comando": "Dame un resumen de hoy"})
+        assert resp.status_code == 200
+        assert "-----" in resp.get_json()["respuesta"]
+    finally:
+        router.contar_no_leidos = original_contar
+        router.remitentes_hoy = original_remitentes
+        router.resumen_correos_hoy = original_resumen

--- a/tests/test_fake_gmail.py
+++ b/tests/test_fake_gmail.py
@@ -1,21 +1,52 @@
 import os
+import importlib
+import os
+import importlib
 
 os.environ["USE_FAKE_GMAIL"] = "1"
-os.environ["FAKE_EMAILS_PATH"] = "tests/fixtures/emails_home.json"
+FIXTURE = "tests/fixtures/emails_home.json"
 
-from core.gmail import listar, leer_ultimo, remitentes_hoy, contar_no_leidos, buscar
 
-def test_listar():
-    assert len(listar()) == 20
+def _reload_gmail(monkeypatch, *, path: str | None = None, file: str | None = None):
+    if path:
+        monkeypatch.setenv("FAKE_EMAILS_PATH", path)
+    else:
+        monkeypatch.delenv("FAKE_EMAILS_PATH", raising=False)
+    if file:
+        monkeypatch.setenv("FAKE_EMAILS_FILE", file)
+    else:
+        monkeypatch.delenv("FAKE_EMAILS_FILE", raising=False)
+    import core.gmail as gmail
+    importlib.reload(gmail)
+    return gmail
 
-def test_leer_ultimo():
-    assert leer_ultimo().get("id") == "m_00071"
 
-def test_remitentes_hoy():
-    assert remitentes_hoy() == []
+def test_listar(monkeypatch):
+    gmail = _reload_gmail(monkeypatch, path=FIXTURE)
+    assert len(gmail.listar()) == 20
 
-def test_contar_no_leidos():
-    assert contar_no_leidos() == 200
 
-def test_buscar():
-    assert buscar("project") == []
+def test_leer_ultimo(monkeypatch):
+    gmail = _reload_gmail(monkeypatch, path=FIXTURE)
+    assert gmail.leer_ultimo().get("id") == "m_00071"
+
+
+def test_remitentes_hoy(monkeypatch):
+    gmail = _reload_gmail(monkeypatch, path=FIXTURE)
+    assert gmail.remitentes_hoy() == []
+
+
+def test_contar_no_leidos(monkeypatch):
+    gmail = _reload_gmail(monkeypatch, path=FIXTURE)
+    assert gmail.contar_no_leidos() == 200
+
+
+def test_buscar(monkeypatch):
+    gmail = _reload_gmail(monkeypatch, path=FIXTURE)
+    assert gmail.buscar("project") == []
+
+
+def test_fixture_via_file(monkeypatch):
+    gmail = _reload_gmail(monkeypatch, file=FIXTURE)
+    assert len(gmail.listar()) == 20
+

--- a/utils/summarizer.py
+++ b/utils/summarizer.py
@@ -1,6 +1,7 @@
 # utils/summarizer.py
 from typing import List, Dict, Any, Optional
 import os, re, base64, html
+from core.gmail.auth import get_authenticated_service
 
 # --- Config desde entorno ---
 SUMMARY_MAX_CHARS = int(os.getenv("SUMMARY_MAX_CHARS", "350"))
@@ -223,7 +224,8 @@ def _compose_item(meta: Dict[str, Any], clean_body: str) -> Optional[str]:
 
 # ---------- Endpoint: resumen de correos de hoy ----------
 
-def resumen_correos_hoy(service, cantidad: int = 10) -> str:
+def resumen_correos_hoy(cantidad: int = 10) -> str:
+    service = get_authenticated_service()
     n = max(1, min(int(cantidad), GMAIL_MAX_RESULTS))
     ids = _list_primary_message_ids(service, n, base_query="newer_than:1d")
     if not ids:


### PR DESCRIPTION
Summary

- Log backend y latencia en helpers de Gmail para benchmarking.
- Exponer flags de modo fake en `.env.example` y separar dependencias opcionales (LLM/audio) en archivos aparte.
- Agregar script local de benchmark, backend fake y docs para pruebas offline.
- Helpers reales de Gmail ahora crean `service` internamente, eliminando el parámetro en `listar`, `remitentes_hoy`, `leer_ultimo`, `contar_no_leidos` y `buscar`.
- El resumen de correos del día obtiene `service` dentro del helper y el enrutador lo invoca sin argumentos adicionales.
- Documentado que los helpers ya no aceptan `service`.
- Tests de comandos (`remitentes_hoy`, `contar_no_leidos`, `resumen_hoy`) en modo fake + LLM local validados.

Archivos tocados

- `core/gmail/__init__.py`: wrappers actualizados y creación interna de `service`.
- `utils/fake_gmail.py`: soporte para `service` opcional y mejoras de date/today.
- `core/action_router.py`: llamadas a helpers sin `service`.
- `requirements*.txt`: separación core / extras.
- `README.md`: docs de extras, proxy note, benchmark, uso de alias fake y eliminación de `service` en helpers.
- `tests/test_fake_gmail.py` y `tests/test_comandos.py`: cobertura de backend fake y comandos end-to-end.

Pruebas ejecutadas

- ✅ USE_FAKE_GMAIL=1 pytest tests/test_fake_gmail.py tests/test_comandos.py
- ✅ FAKE_EMAILS_PATH=tests/fixtures/emails_home.json USE_FAKE_GMAIL=1 python tools/benchmark_local.py
- ❌ pip install -r requirements.txt (bloqueo por proxy en jsonschema)
- 🔜 Smoke real pendiente (OAuth + token.json).

Checklist DoD

- [x] requirements.txt solo core.
- [x] CI no falla sin jsonschema.
- [x] Tests fake verdes.
- [x] Skips condicionales aplicados.
- [x] README actualizado.
- [x] Helpers sin `service` y compatibilidad mantenida.
- [x] Comandos end-to-end funcionando con LLM local.

Próximos pasos

- Smoke real con OAuth y tabla P50/P95 (real vs fake).
- Infra proxy para pip / mirrors.
